### PR TITLE
Control flow implementation

### DIFF
--- a/src/core/ast.luau
+++ b/src/core/ast.luau
@@ -7,9 +7,10 @@ local nodeTypes = {
 	BooleanLiteral = "BooleanLiteral",
 	Identifier = "Identifier",
 	BinaryExpr = "BinaryExpr",
-	UnaryExpr = "UnaryExpr", -- for future 'not' operator
+	UnaryExpr = "UnaryExpr",
 	VariableDeclaration = "VariableDeclaration",
 	Assignment = "Assignment",
+	IfStatement = "IfStatement",
 }
 
 export type statement = { kind: string }
@@ -25,6 +26,23 @@ export type binaryExpr = { kind: "BinaryExpr", left: expression, operator: strin
 export type unaryExpr = { kind: "UnaryExpr", operator: string, argument: expression }
 export type variableDeclaration = { kind: "VariableDeclaration", identifier: identifier, value: expression }
 export type assignment = { kind: "Assignment", identifier: identifier, value: expression }
+
+-- IfStatement structure:
+-- given (condition) then
+--   body
+-- however (condition) then
+--   body
+-- otherwise
+--   body
+-- finish
+export type ifBranch = { condition: expression, body: { statement } }
+export type ifStatement = {
+	kind: "IfStatement",
+	condition: expression,
+	consequent: { statement },
+	alternates: { ifBranch }, -- however clauses
+	alternate: { statement }?, -- otherwise clause
+}
 
 local function program(body: { statement }): program
 	return { kind = nodeTypes.Program, body = body }
@@ -62,6 +80,21 @@ local function assignment(id: identifier, value: expression): assignment
 	return { kind = nodeTypes.Assignment, identifier = id, value = value }
 end
 
+local function ifStatement(
+	condition: expression,
+	consequent: { statement },
+	alternates: { ifBranch },
+	alternate: { statement }?
+): ifStatement
+	return {
+		kind = nodeTypes.IfStatement,
+		condition = condition,
+		consequent = consequent,
+		alternates = alternates,
+		alternate = alternate,
+	}
+end
+
 return {
 	nodeTypes = nodeTypes,
 	program = program,
@@ -73,4 +106,5 @@ return {
 	unaryExpression = unaryExpression,
 	variableDeclaration = variableDeclaration,
 	assignment = assignment,
+	ifStatement = ifStatement,
 }

--- a/src/core/evaluator.luau
+++ b/src/core/evaluator.luau
@@ -17,6 +17,8 @@ type stringLiteral = ast.stringLiteral
 type booleanLiteral = ast.booleanLiteral
 type variableDeclaration = ast.variableDeclaration
 type assignment = ast.assignment
+type ifStatement = ast.ifStatement
+type ifBranch = ast.ifBranch
 
 local function evaluate(node: statement | expression, env: environment): runtimeValue
 	if node.kind == ast.nodeTypes.Program then
@@ -41,6 +43,53 @@ local function evaluate(node: statement | expression, env: environment): runtime
 		-- ensure variable exists
 		env:assign(assign.identifier.symbol, value)
 		return value
+	end
+
+	if node.kind == ast.nodeTypes.IfStatement then
+		local ifStmt = node :: ifStatement
+
+		-- evaluate main condition
+		local conditionValue = evaluate(ifStmt.condition, env)
+		if type(conditionValue) ~= "boolean" then
+			error("(evaluator.evaluate) if condition must be a boolean")
+		end
+
+		if conditionValue then
+			-- execute consequent
+			local result: runtimeValue = false
+			for _, stmt in ifStmt.consequent do
+				result = evaluate(stmt, env)
+			end
+			return result
+		end
+
+		-- check however clauses (elseif)
+		for _, branch in ifStmt.alternates do
+			local branchCondition = evaluate(branch.condition, env)
+			if type(branchCondition) ~= "boolean" then
+				error("(evaluator.evaluate) however condition must be a boolean")
+			end
+
+			if branchCondition then
+				local result: runtimeValue = false
+				for _, stmt in branch.body do
+					result = evaluate(stmt, env)
+				end
+				return result
+			end
+		end
+
+		-- otherwise clause (else)
+		if ifStmt.alternate then
+			local result: runtimeValue = false
+			for _, stmt in ifStmt.alternate do
+				result = evaluate(stmt, env)
+			end
+			return result
+		end
+
+		-- no branch taken
+		return false
 	end
 
 	if node.kind == ast.nodeTypes.NumericLiteral then

--- a/src/parser/keywords.luau
+++ b/src/parser/keywords.luau
@@ -7,4 +7,9 @@ return {
 	["and"] = "AND",
 	["or"] = "OR",
 	["not"] = "NOT",
+	["given"] = "GIVEN",
+	["then"] = "THEN",
+	["otherwise"] = "OTHERWISE",
+	["however"] = "HOWEVER",
+	["finish"] = "FINISH",
 } :: { [any]: string }

--- a/src/parser/parser.luau
+++ b/src/parser/parser.luau
@@ -9,6 +9,7 @@ type program = ast.program
 type statement = ast.statement
 type expression = ast.expression
 type identifier = ast.identifier
+type ifBranch = ast.ifBranch
 
 export type parser = {
 	tokens: { token },
@@ -22,6 +23,7 @@ export type parser = {
 	parseProgram: (self: parser) -> program,
 	parseStatement: (self: parser) -> statement,
 	parseVariableDeclaration: (self: parser) -> statement,
+	parseIfStatement: (self: parser) -> statement,
 
 	parseExpression: (self: parser) -> expression,
 	parseOr: (self: parser) -> expression,
@@ -85,6 +87,10 @@ function parser.parseStatement(self: parser): statement
 		return self:parseVariableDeclaration()
 	end
 
+	if t.type == tokens.GIVEN then
+		return self:parseIfStatement()
+	end
+
 	return self:parseExpression()
 end
 
@@ -97,6 +103,63 @@ function parser.parseVariableDeclaration(self: parser): statement
 
 	local value = self:parseExpression()
 	return ast.variableDeclaration(ast.identifier(name.value), value) :: statement
+end
+
+-- given (condition) then
+--   body
+-- however (condition) then
+--   body
+-- otherwise
+--   body
+-- finish
+function parser.parseIfStatement(self: parser): statement
+	self:consume() -- given
+
+	-- parse condition
+	self:expect(tokens.OPEN_PARENTHESIS, "(parser.parseIfStatement) expected '(' after 'given'")
+	local condition = self:parseExpression()
+	self:expect(tokens.CLOSE_PARENTHESIS, "(parser.parseIfStatement) expected ')' after condition")
+	self:expect(tokens.THEN, "(parser.parseIfStatement) expected 'then' after condition")
+
+	-- parse consequent body (statements until 'however', 'otherwise', or 'finish')
+	local consequent: { statement } = {}
+	while self:at() and (self:at() :: token).type ~= tokens.HOWEVER and (self:at() :: token).type ~= tokens.OTHERWISE and (self:at() :: token).type ~= tokens.FINISH do
+		consequent[#consequent + 1] = self:parseStatement()
+	end
+
+	-- parse however clauses (elseif)
+	local alternates: { ifBranch } = {}
+	while self:at() and (self:at() :: token).type == tokens.HOWEVER do
+		self:consume() -- however
+
+		self:expect(tokens.OPEN_PARENTHESIS, "(parser.parseIfStatement) expected '(' after 'however'")
+		local howeverCondition = self:parseExpression()
+		self:expect(tokens.CLOSE_PARENTHESIS, "(parser.parseIfStatement) expected ')' after however condition")
+		self:expect(tokens.THEN, "(parser.parseIfStatement) expected 'then' after however condition")
+
+		local howeverBody: { statement } = {}
+		while self:at() and (self:at() :: token).type ~= tokens.HOWEVER and (self:at() :: token).type ~= tokens.OTHERWISE and (self:at() :: token).type ~= tokens.FINISH do
+			howeverBody[#howeverBody + 1] = self:parseStatement()
+		end
+
+		alternates[#alternates + 1] = { condition = howeverCondition, body = howeverBody }
+	end
+
+	-- parse otherwise clause (else)
+	local alternate: { statement }? = nil
+	if self:at() and (self:at() :: token).type == tokens.OTHERWISE then
+		self:consume() -- otherwise
+
+		local otherwiseBody: { statement } = {}
+		while self:at() and (self:at() :: token).type ~= tokens.FINISH do
+			otherwiseBody[#otherwiseBody + 1] = self:parseStatement()
+		end
+		alternate = otherwiseBody
+	end
+
+	self:expect(tokens.FINISH, "(parser.parseIfStatement) expected 'finish' to close if statement")
+
+	return ast.ifStatement(condition, consequent, alternates, alternate) :: statement
 end
 
 function parser.parseExpression(self: parser): expression

--- a/src/parser/tokens.luau
+++ b/src/parser/tokens.luau
@@ -23,6 +23,11 @@ export type tokenTypes = {
 	DIV_EQUALS: string,
 	OPEN_PARENTHESIS: string,
 	CLOSE_PARENTHESIS: string,
+	GIVEN: string,
+	THEN: string,
+	OTHERWISE: string,
+	HOWEVER: string,
+	FINISH: string,
 }
 
 return {
@@ -48,4 +53,9 @@ return {
 	DIV_EQUALS = "DIV_EQUALS",
 	OPEN_PARENTHESIS = "OPEN_PARENTHESIS",
 	CLOSE_PARENTHESIS = "CLOSE_PARENTHESIS",
+	GIVEN = "GIVEN",
+	THEN = "THEN",
+	OTHERWISE = "OTHERWISE",
+	HOWEVER = "HOWEVER",
+	FINISH = "FINISH",
 } :: tokenTypes


### PR DESCRIPTION
This pull request adds support for parsing and evaluating multi-branch conditional statements (if/elseif/else) with new keywords (`given`, `however`, `otherwise`, `finish`). The changes introduce a new AST node for `IfStatement`, update the parser to handle the new syntax, and extend the evaluator to execute these conditional branches.

**Support for multi-branch conditional statements:**

* Added new keywords (`given`, `however`, `otherwise`, `then`, `finish`) to `keywords.luau` and `tokens.luau` to enable the new conditional syntax. [[1]](diffhunk://#diff-abb1ac9bad658249ab5f190d6ddfd7d66ebfcbc533def0d775063750e49f1925R10-R14) [[2]](diffhunk://#diff-ce2bc0c24bb0c2b8ddaac05e3a21780c0cc7483f1125feafd94712732c723450R26-R30) [[3]](diffhunk://#diff-ce2bc0c24bb0c2b8ddaac05e3a21780c0cc7483f1125feafd94712732c723450R56-R60)
* Introduced new AST node types and structures (`IfStatement`, `ifBranch`) in `ast.luau` to represent the new conditional statements. [[1]](diffhunk://#diff-49bdbad7d43dcecce0a28f0fdba535f363d3221fbeceea9924df5c73cefba3e8L10-R13) [[2]](diffhunk://#diff-49bdbad7d43dcecce0a28f0fdba535f363d3221fbeceea9924df5c73cefba3e8R30-R46)
* Implemented construction helper for `IfStatement` in `ast.luau`. [[1]](diffhunk://#diff-49bdbad7d43dcecce0a28f0fdba535f363d3221fbeceea9924df5c73cefba3e8R83-R97) [[2]](diffhunk://#diff-49bdbad7d43dcecce0a28f0fdba535f363d3221fbeceea9924df5c73cefba3e8R109)

**Parser enhancements:**

* Updated `parser.luau` to parse `given`/`however`/`otherwise`/`finish` blocks, building the corresponding AST nodes for multi-branch conditionals. [[1]](diffhunk://#diff-4da3f3685d2233393a4e52418da91c169c98786d498cf9c068c634560d01b57dR26) [[2]](diffhunk://#diff-4da3f3685d2233393a4e52418da91c169c98786d498cf9c068c634560d01b57dR90-R93) [[3]](diffhunk://#diff-4da3f3685d2233393a4e52418da91c169c98786d498cf9c068c634560d01b57dR108-R164)
* Updated type definitions and parser interface to support the new statement type.

**Evaluator support:**

* Extended `evaluator.luau` to evaluate `IfStatement` nodes, including all branches (main, however/elseif, otherwise/else). [[1]](diffhunk://#diff-04a37f097e6560d33303bcd13d8a71208f30560674a07e111e12d6b88d9eea76R20-R21) [[2]](diffhunk://#diff-04a37f097e6560d33303bcd13d8a71208f30560674a07e111e12d6b88d9eea76R48-R94)